### PR TITLE
Update package.json-snyk issue fix SER-9045

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,6 @@
   },
   "dependencies": {
     "d3-save-svg": "0.0.2",
-    "jspdf": "^1.5.3"
+    "jspdf": "^2.5.2"
   }
 }


### PR DESCRIPTION
[jspdf](https://github.com/MrRio/jsPDF) is a PDF Document creation from JavaScript

Affected versions of this package are vulnerable to Regular Expression Denial of Service (ReDoS). ReDoS is possible via the addImage function.

Solution : upgrade version of jsPDF